### PR TITLE
fix(tree): show filename alongside YAML title

### DIFF
--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -15,7 +15,7 @@ export function flattenTree(
     const hasChildren = Array.isArray(n.children) && n.children.length > 0;
     // Include hasChildren so virtual row renderers can decide whether to show toggles
     // Preserve optional fields like `extension` so file icons can render
-    out.push({ id: n.id, name: n.name, kind: n.kind, extension: n.extension, level, hasChildren });
+    out.push({ id: n.id, name: n.name, title: n.title, kind: n.kind, extension: n.extension, level, hasChildren });
     if (hasChildren) {
       const isOpen = expandedMap.get(n.id) ?? n.expanded ?? false;
       if (isOpen && Array.isArray(n.children) && n.children.length) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface TreeNode {
 export interface VirtualTreeBaseItem {
     id: string;
     name: string;
+    title?: string;
     kind: 'file' | 'folder' | 'virtual';
     // Optional file extension (present for files when available)
     extension?: string;

--- a/src/views/VirtualizedTree.ts
+++ b/src/views/VirtualizedTree.ts
@@ -147,7 +147,8 @@ export class ComplexVirtualTree extends VirtualTree {
       const kindChanged = o.kind !== n.kind;
       const extChanged = (o.extension || '') !== (n.extension || '');
       const nameChanged = o.name !== n.name;
-      if (kindChanged || extChanged || nameChanged) dirtyIds.add(id);
+      const titleChanged = (o.title || '') !== (n.title || '');
+      if (kindChanged || extChanged || nameChanged || titleChanged) dirtyIds.add(id);
     });
 
     // Swap data and recompute visible rows based on current expansion map

--- a/src/views/rowDom.ts
+++ b/src/views/rowDom.ts
@@ -1,8 +1,8 @@
-import { App, setIcon } from 'obsidian';
+import { setIcon } from 'obsidian';
+import type { App } from 'obsidian';
 import { t } from '../i18n';
 import type { RowItem } from './viewTypes';
 import type { VItem } from '../core/virtualData';
-import { getYamlTitle } from '../utils/YamlTitleUtils';
 
 export function createIndentGuides(level: number): HTMLElement {
   const indent = document.createElement('div');
@@ -65,7 +65,7 @@ export function createFileIconOrBadge(item: RowItem): HTMLElement | null {
   return badge;
 }
 
-export function createTitleElement(item: RowItem, app: App): HTMLElement {
+export function createTitleElement(item: RowItem): HTMLElement {
   const titleClass = item.kind === 'virtual'
     ? 'dotn_tree-item-title mod-create-new'
     : item.kind === 'file'
@@ -78,24 +78,18 @@ export function createTitleElement(item: RowItem, app: App): HTMLElement {
   title.setAttribute('data-path', item.id);
 
   // Check for YAML custom title
-  const yamlTitle = getYamlTitle(app, item.id);
-
-  if (yamlTitle) {
+  if (item.title) {
     // Create custom title span
     const customTitle = document.createElement('span');
-    customTitle.textContent = yamlTitle;
+    customTitle.textContent = item.title;
     customTitle.className = 'yaml-custom-title';
 
-    // Create separator
-    const separator = document.createTextNode(' — ');
-
-    // Create filename span (grayed out)
+    // Create filename span with slight transparency
     const filename = document.createElement('span');
     filename.textContent = item.name;
-    filename.className = 'yaml-filename';
+    filename.className = 'yaml-filename ml-1';
 
     title.appendChild(customTitle);
-    title.appendChild(separator);
     title.appendChild(filename);
   } else {
     // Use original filename display

--- a/src/views/rowRender.ts
+++ b/src/views/rowRender.ts
@@ -63,7 +63,7 @@ export function renderRow(vt: VirtualTreeLike, row: HTMLElement, item: RowItem, 
     const ic = createFileIconOrBadge(item);
     if (ic) row.appendChild(ic);
   }
-  row.appendChild(createTitleElement(item, app));
+  row.appendChild(createTitleElement(item));
   const extEl = maybeCreateExtension(item);
   if (extEl) row.appendChild(extEl);
   row.appendChild(createActionButtons(item, app));

--- a/styles.css
+++ b/styles.css
@@ -137,6 +137,7 @@
         margin-left: 0;
         border-radius: var(--dotn_border-radius);
         background-color: var(--dotn_bg-hover);
+        color: var(--dotn_color-text-hover);
     }
     
     .dotn_tree-item-title[data-node-kind="folder"] {
@@ -154,7 +155,7 @@
     }
 
     .yaml-filename {
-        color: var(--text-muted);
+        opacity: 0.6;
         font-weight: 400;
     }
 


### PR DESCRIPTION
## Summary
- show original filename with YAML title in tree view
- tone down original filename color and remove separator
- increase default title contrast
- ensure YAML titles propagate through flattened data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c58bcf066c8329bf2bf9876d5f4a96