### PR TITLE
fix: resolve build and lint issues

### DIFF
--- a/src/core/virtualData.ts
+++ b/src/core/virtualData.ts
@@ -28,18 +28,6 @@ export function nodeKind(node: TreeNode): Kind {
   return 'virtual';
 }
 
-function rawName(node: TreeNode): string {
-  const base = FileUtils.basename(node.path);
-  if (node.nodeType === TreeNodeType.FOLDER) return base.replace(/ \(\d+\)$/u, '');
-  const matched = base.match(/([^.]+)\.[^.]+$/u);
-  return (matched ? matched[1] : base).replace(/ \(\d+\)$/u, '');
-}
-
-function sortKey(app: App, node: TreeNode): string {
-  const yaml = getYamlTitle(app, node.path);
-  return yaml ?? rawName(node);
-}
-
 export function extOf(path: string): string | undefined {
   const idx = path.lastIndexOf('.');
   return idx > -1 ? path.slice(idx + 1) : undefined;
@@ -78,7 +66,7 @@ export function buildVirtualizedData(app: App, root: TreeNode): VirtualizedData 
     if (node.children && node.children.size > 0) {
       const children: VItem[] = [];
       Array.from(node.children.entries())
-        .sort(([_aKey, aNode], [_bKey, bNode]) => sortKey(app, aNode).localeCompare(sortKey(app, bNode)))
+        .sort(([_aKey, aNode], [_bKey, bNode]) => sortKey(aNode).localeCompare(sortKey(bNode)))
         .forEach(([, child]) => {
           children.push(build(child, node.path));
         });
@@ -90,7 +78,7 @@ export function buildVirtualizedData(app: App, root: TreeNode): VirtualizedData 
 
   const data: VItem[] = [];
   Array.from(root.children.entries())
-    .sort(([_aKey, aNode], [_bKey, bNode]) => sortKey(app, aNode).localeCompare(sortKey(app, bNode)))
+    .sort(([_aKey, aNode], [_bKey, bNode]) => sortKey(aNode).localeCompare(sortKey(bNode)))
     .forEach(([, child]) => data.push(build(child, root.path)));
 
   return { data, parentMap };

--- a/src/views/rowDom.ts
+++ b/src/views/rowDom.ts
@@ -77,11 +77,11 @@ export function createTitleElement(item: RowItem): HTMLElement {
   title.setAttribute('data-node-kind', item.kind);
   title.setAttribute('data-path', item.id);
 
-  const yamlTitle = item.title ?? getYamlTitle(app, item.id);
+  const yamlTitle = item.title;
 
   if (yamlTitle) {
     const customTitle = document.createElement('span');
-    customTitle.textContent = item.title;
+    customTitle.textContent = yamlTitle;
     customTitle.className = 'yaml-custom-title';
 
     const separator = document.createElement('span');
@@ -93,6 +93,7 @@ export function createTitleElement(item: RowItem): HTMLElement {
     filename.className = 'yaml-filename font-italic';
 
     title.appendChild(customTitle);
+    title.appendChild(separator);
     title.appendChild(filename);
   } else {
     title.textContent = item.name;


### PR DESCRIPTION
## Summary
- simplify virtual data sorting and remove unused helpers
- rely on existing titles when rendering rows and include filename separator

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b80c984c832988fffedfc202a5f4