### PR TITLE
fix: detect YAML title changes via metadata events

### DIFF
--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -42,13 +42,27 @@ export class Notice {
     }
 }
 
+export class MetadataCache {
+    on(__name: string, __callback: (...args: unknown[]) => void): void {
+        /* no-op */
+    }
+    off(__name: string, __callback: (...args: unknown[]) => void): void {
+        /* no-op */
+    }
+    getFileCache(__file: TFile): unknown {
+        return null;
+    }
+}
+
 export class App {
     vault: Vault;
     workspace: Workspace;
+    metadataCache: MetadataCache;
 
     constructor() {
         this.vault = new Vault();
         this.workspace = new Workspace();
+        this.metadataCache = new MetadataCache();
     }
 }
 


### PR DESCRIPTION
## Summary
- listen to metadata cache change events to update YAML title cache
- extend test Obsidian mock with metadata cache API
- replace `any` types in metadata mock to satisfy lint

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb6051bc8329a891fae9640de3be