### PR TITLE
feat: refine mobile rename modal interactions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1262,23 +1262,68 @@
 .is-mobile .modal:has(.rename-dialog-content) {
     left: var(--size-4-3) !important;
     right: var(--size-4-3) !important;
+    top: var(--size-4-3) !important;
+    bottom: var(--size-4-3) !important;
     width: auto !important;
+    max-height: calc(100% - (var(--size-4-3) * 2));
+    display: flex;
+    flex-direction: column;
 
     .prompt-instructions {
         display: none;
     }
+}
 
-    .rename-submit-container {
-        margin-top: 16px;
-        text-align: center;
-    }
+.is-mobile .modal:has(.rename-dialog-content) .modal-content {
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+    overflow: hidden;
+}
 
-    .rename-submit-button {
-        min-width: 120px;
-        padding: 12px 24px;
-        font-size: 16px;
-    }
+.is-mobile .rename-mobile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
 
+.is-mobile .rename-mobile-title {
+    flex: 1;
+    text-align: center;
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.is-mobile .rename-mobile-close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    padding: 6px;
+    border-radius: 6px;
+    color: var(--text-muted);
+}
+
+.is-mobile .rename-mobile-close-button:hover,
+.is-mobile .rename-mobile-close-button:focus {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.is-mobile .rename-mobile-submit-button {
+    white-space: nowrap;
+    padding: 8px 16px;
+    font-size: 15px;
+}
+
+.is-mobile .rename-mobile-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
 }
 
 /* Mobile: show buttons container and position buttons vertically */


### PR DESCRIPTION
## Summary
- blur rename inputs on mobile submission and add swipe-to-close detection that ignores suggestions or diff panes
- restructure the mobile dialog layout with a header that hosts close/submit controls and removes the bottom button
- tweak mobile modal sizing styles to keep the dialog compact and leave space to tap outside

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdbeebbcf08329890acabc262208ca